### PR TITLE
Tiles are in place

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -37,6 +37,7 @@ set( HDRS
     ${HEADERS_TYPE}/Tile.h
     ${HEADERS_TYPE}/TileMap.h
     ${HEADERS_TYPE}/TileTexture.h
+    ${HEADERS_TYPE}/ViewData.h
 )
 
 set( SRCS

--- a/lib/include/impl/DataKeeper.h
+++ b/lib/include/impl/DataKeeper.h
@@ -27,8 +27,7 @@ public:
     void rotateGlobe( int pixelX, int pixelY );
     void balanceGlobe();
 
-    void newTileTexture( const TileTexture& );
-    void updateTexture( const std::vector<TileImage>& );
+    void updateTexture( std::vector<GLfloat> /*vbo*/, int /*texW*/, int /*texH*/, std::vector<unsigned char> /*data*/ );
 
     std::tuple<GLuint, GLsizei> simpleTriangle() const;
     std::tuple<GLuint, GLsizei> wireGlobe() const;
@@ -38,6 +37,7 @@ public:
     boost::signals2::signal<float()> getMeterInPixel;
     boost::signals2::signal<std::shared_ptr<Projector>()> getProjector;
     boost::signals2::signal<void()> globeRotated;
+    boost::signals2::signal<void( bool )> mapReady;
 
 private:
     void composeWireGlobe();

--- a/lib/include/impl/MapGenerator.h
+++ b/lib/include/impl/MapGenerator.h
@@ -1,13 +1,22 @@
 #pragma once
 
+#include <atomic>
+#include <mutex>
+#include <thread>
 #include <vector>
 
+#include <boost/asio/connect.hpp>
+#include <boost/asio/ip/tcp.hpp>
 #include <boost/signals2.hpp>
 
 #include "type/TileTexture.h"
+#include "type/ViewData.h"
 
 
 namespace gv {
+
+
+class Projector;
 
 
 class MapGenerator
@@ -16,20 +25,21 @@ public:
     MapGenerator();
     ~MapGenerator();
 
-    void regenerateMap();
+    void init( ViewData );
+    void updateGlobe();
+    void updateViewData( ViewData );
+    void getTiles( const std::vector<TileImage>& );
 
-    boost::signals2::signal<float()> getUnitInMeter;
-    boost::signals2::signal<float()> getMeterInPixel;
-    boost::signals2::signal<int()> getMapZoomLevel;
-    boost::signals2::signal<std::tuple<double, double, double, double>()> getViewBorder;
-    boost::signals2::signal<std::tuple<int, int>()> getViewPixelSize;
-    boost::signals2::signal<std::tuple<double, double>()> getProjectionCenter;
-    boost::signals2::signal<std::tuple<bool, double, double>( double, double )> getInvProjection;
-    boost::signals2::signal<std::tuple<bool, double, double>( double, double )> getFwdProjection;
-    boost::signals2::signal<void( TileTexture )> sendTileTexture;
+    boost::signals2::signal<std::shared_ptr<Projector>()> getProjector;
     boost::signals2::signal<void( std::vector<TileHead> )> requestTiles;
+    boost::signals2::signal<void( bool )> mapReady;
+    boost::signals2::signal<void( std::vector<GLfloat> /*vbo*/, int /*texW*/, int /*texH*/,
+        std::vector<unsigned char> /*data*/)> updateMapTexture;
 
 private:
+    void checkStates();
+    void cleanupCheck();
+    void regenerateMap();
     int lonToTileX( double lon, int z ) const;
     int latToTileY( double lat, int z ) const;
     double tileXToLon( int x, int z ) const;
@@ -38,6 +48,26 @@ private:
     std::vector<TileHead> findTilesToProcess( int z, int x, int y );
     bool tileVisible( TileHead );
     void composeTileTexture( const std::vector<TileHead>& );
+    void vboFromTileTexture( TileTexture );
+    void finalize();
+
+    boost::asio::io_context ioc_;
+    boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work_;
+    std::vector<std::thread> threads_;
+
+    std::shared_ptr<Projector> projector_;
+    ViewData viewData_;
+    ViewData newViewData_;
+    TileTexture tileTex_;
+
+    std::vector<GLfloat> vbo_;
+    std::vector<unsigned char> data_;
+
+    std::mutex mutexState_;
+    bool active_;
+    bool pending_;
+    std::atomic<bool> gotTiles_;
+    std::atomic<bool> calcedVbo_;
 };
 
 

--- a/lib/include/impl/Renderer.h
+++ b/lib/include/impl/Renderer.h
@@ -25,6 +25,7 @@ public:
     ~Renderer();
 
     void render();
+    void setMapReady( bool );
 
     boost::signals2::signal<glm::mat4()> getProjection;
     boost::signals2::signal<std::tuple<GLuint, GLsizei>()> renderSimpleTriangle;
@@ -38,6 +39,7 @@ private:
     std::unique_ptr<support::Shader> shaderTexture_;
     GLint stProj_;
     GLint stSample_;
+    bool mapReady_;
 };
 
 

--- a/lib/include/impl/Viewport.h
+++ b/lib/include/impl/Viewport.h
@@ -7,6 +7,7 @@
 #include <glm/gtc/matrix_transform.hpp>
 
 #include "LoadGL.h"
+#include "type/ViewData.h"
 
 
 namespace gv {
@@ -23,6 +24,7 @@ public:
     void zoom( int steps );
     void center();
 
+    ViewData viewData() const;
     float unitInMeter() const;
     float meterInPixel() const;
     int mapZoomLevel( int tileWidth ) const;
@@ -32,11 +34,10 @@ public:
 
     glm::mat4 projection() const;
 
-    boost::signals2::signal<void()> projectionUpdated;
+    boost::signals2::signal<void( ViewData )> viewUpdated;
 
 private:
     void setProjection();
-    void testPrint() const;
 
     int pixelW_;    //!< Width of viewport (in pixels)
     int pixelH_;    //!< Height of viewport (in pixels)

--- a/lib/include/type/Tile.h
+++ b/lib/include/type/Tile.h
@@ -49,7 +49,8 @@ struct TileBody
     float ty0;      //!< texture y coordinate of left-bottom corner
     float tx1;      //!< texture x coordinate of right-top corner
     float ty1;      //!< texture y coordinate of right-top corner
-    bool visible;   //!< currently visible
+    int row;        //!< row number in texture
+    int col;        //!< column number in texture
 
     TileBody() = default;
     TileBody( const TileBody& rhs ) = default;
@@ -65,7 +66,8 @@ struct TileBody
         ty0 = rhs.ty0;
         tx1 = rhs.tx1;
         ty1 = rhs.ty1;
-        visible = rhs.visible;
+        row = rhs.row;
+        col = rhs.col;
         return *this;
     }
 
@@ -79,7 +81,8 @@ struct TileBody
         ty0 = std::move( rhs.ty0 );
         tx1 = std::move( rhs.tx1 );
         ty1 = std::move( rhs.ty1 );
-        visible = std::move( rhs.visible );
+        row = std::move( rhs.row );
+        col = std::move( rhs.col );
         return *this;
     }
 };

--- a/lib/include/type/TileTexture.h
+++ b/lib/include/type/TileTexture.h
@@ -12,7 +12,7 @@ namespace gv {
 
 struct TileTexture
 {
-    std::tuple<int, int> textureSize;   //!< (width, height) of tile texture in tile numbers
+    std::tuple<int, int> textureSize;   //!< (rows, cols) of tile texture in tile numbers
     int tileCount;                      //!< total number of tiles
     int tileFilled;                     //!< number of tiles with TileData filled (got its image)
     TileMap tiles;                      //!< tiles themselves

--- a/lib/include/type/ViewData.h
+++ b/lib/include/type/ViewData.h
@@ -1,0 +1,22 @@
+#pragma once
+
+
+namespace gv {
+
+
+struct ViewData
+{
+    float unitInMeter;
+    float meterInPixel;
+    int mapZoomLevel;
+    float glX0;
+    float glX1;
+    float glY0;
+    float glY1;
+    int pixWidth;
+    int pixHeight;
+};
+
+
+}
+

--- a/lib/src/MapGenerator.cpp
+++ b/lib/src/MapGenerator.cpp
@@ -2,8 +2,11 @@
 #include <cmath>
 
 #include "Defines.h"
+#include "LoadGL.h"
 #include "MapGenerator.h"
 #include "Profiler.h"
+#include "Projector.h"
+#include "stb_image.h"
 #include "ThreadSafePrinter.hpp"
 
 
@@ -18,12 +21,145 @@ using namespace support;
 
 
 MapGenerator::MapGenerator()
+    : ioc_()
+    , work_( make_work_guard( ioc_ ) )
+    , active_( false )
+    , pending_( false )
+    , gotTiles_( false )
+    , calcedVbo_( false )
 {
+    threads_.emplace_back( [this]() { ioc_.run(); } );
 }
 
 
 MapGenerator::~MapGenerator()
 {
+    work_.reset();
+    ioc_.stop();
+
+    for ( auto&& t : threads_ )
+    {
+        if ( t.joinable() )
+        {
+            t.join();
+        }
+    }
+}
+
+
+void MapGenerator::init( ViewData vd )
+{
+    if ( !getProjector() )
+    {
+        throw std::logic_error( "Cannot initialize MapGenerator: getProjector is not defined!" );
+    }
+    else
+    {
+        projector_ = *getProjector();
+    }
+
+    newViewData_ = vd;
+    viewData_ = vd;
+}
+
+
+void MapGenerator::updateGlobe()
+{
+    checkStates();
+}
+
+
+void MapGenerator::updateViewData( ViewData vd )
+{
+    newViewData_ = vd;
+    checkStates();
+}
+
+
+void MapGenerator::getTiles( const std::vector<TileImage>& vec )
+{
+    data_.clear();
+    
+    if ( vec.empty() )
+    {
+        return;
+    }
+    
+    int rowNum;
+    int colNum;
+    std::tie( colNum, rowNum ) = tileTex_.textureSize;
+    const int channels = 3;
+    const int tileW = defs::tileSide * channels;
+    const int texW = tileW * colNum;
+
+    data_.resize( defs::tileSide * tileW * rowNum * colNum, 0 );
+
+    const auto& tiles = tileTex_.tiles;
+    int w;
+    int h;
+    int chans;
+    stbi_set_flip_vertically_on_load( true );
+
+    for ( const auto& ti : vec )
+    {
+        auto it = tiles.find( ti.head );
+
+        if ( it != tiles.end() )
+        {
+            const auto& row = it->second.row;
+            const auto& col = it->second.col;
+
+            auto buffer = stbi_load_from_memory( &ti.data.data[0], ti.data.data.size(), &w, &h, &chans, 0 );
+            
+            for ( int i = 0; i < defs::tileSide; ++i )
+            {
+                memcpy( &data_[( row * defs::tileSide + i ) * texW + col * tileW], &buffer[i * tileW], tileW );
+            }
+            
+            stbi_image_free( buffer );
+        }
+    }
+
+    gotTiles_.store( true );
+    finalize();
+}
+
+
+void MapGenerator::checkStates()
+{
+    std::lock_guard<std::mutex> lock( mutexState_ );
+
+    if ( active_ )
+    {
+        pending_ = true;
+        return;
+    }
+    else
+    {
+        active_ = true;
+        viewData_ = newViewData_;
+        mapReady( false );
+        ioc_.post( [this] { regenerateMap(); } );
+    }
+}
+
+
+void MapGenerator::cleanupCheck()
+{
+    std::lock_guard<std::mutex> lock( mutexState_ );
+
+    if ( pending_ )
+    {
+        pending_ = false;
+        ioc_.post( [this] { regenerateMap(); } );
+    }
+    else
+    {
+        int w = std::get<0>( tileTex_.textureSize ) * defs::tileSide;
+        int h = std::get<1>( tileTex_.textureSize ) * defs::tileSide;
+        updateMapTexture( vbo_, w, h, data_ );
+        active_ = false;
+    }
 }
 
 
@@ -36,40 +172,16 @@ void MapGenerator::regenerateMap()
 
     if ( !visiblePoint( lon, lat ) )
     {
-        //TSP() << "No visible point!";
+        cleanupCheck();
         return;
     }
 
-    //TSP() << "Visible point at: " << lon << ":" << lat;
-
-    int mapZoomLevel = *getMapZoomLevel();
+    int mapZoomLevel = viewData_.mapZoomLevel;
     int x = lonToTileX( lon, mapZoomLevel );
     int y = latToTileY( lat, mapZoomLevel );
 
-    //TSP() << "zoom, tile: " << mapZoomLevel << ", " << x << ":" << y;
-
-    //TSP() << "Testing for level 0\n"
-    //    << "0:0 " << tileXToLon( 0, 0 ) << ":" << tileYToLat( 0, 0 ) << "\n"
-    //    << "1:0 " << tileXToLon( 1, 0 ) << ":" << tileYToLat( 0, 0 ) << "\n"
-    //    << "0:1 " << tileXToLon( 0, 0 ) << ":" << tileYToLat( 1, 0 ) << "\n"
-    //    << "1:1 " << tileXToLon( 1, 0 ) << ":" << tileYToLat( 1, 0 ) << "\n"
-    //    << "Testing for level 1\n"
-    //    << "0:0 " << tileXToLon( 0, 1 ) << ":" << tileYToLat( 0, 1 ) << "\n"
-    //    << "1:0 " << tileXToLon( 1, 1 ) << ":" << tileYToLat( 0, 1 ) << "\n"
-    //    << "2:0 " << tileXToLon( 2, 1 ) << ":" << tileYToLat( 0, 1 ) << "\n"
-    //    << "3:0 " << tileXToLon( 3, 1 ) << ":" << tileYToLat( 0, 1 ) << "\n"
-    //    << "4:0 " << tileXToLon( 4, 1 ) << ":" << tileYToLat( 0, 1 ) << "\n"
-    //    << "0:1 " << tileXToLon( 0, 1 ) << ":" << tileYToLat( 1, 1 ) << "\n"
-    //    << "0:2 " << tileXToLon( 0, 1 ) << ":" << tileYToLat( 2, 1 ) << "\n"
-    //    << "0:3 " << tileXToLon( 0, 1 ) << ":" << tileYToLat( 3, 1 ) << "\n"
-    //    << "0:4 " << tileXToLon( 0, 1 ) << ":" << tileYToLat( 4, 1 ) << "\n"
-    //    << "1:1 " << tileXToLon( 1, 1 ) << ":" << tileYToLat( 1, 1 ) << "\n"
-    //    << "2:2 " << tileXToLon( 2, 1 ) << ":" << tileYToLat( 2, 1 ) << "\n"
-    //    << "3:3 " << tileXToLon( 3, 1 ) << ":" << tileYToLat( 3, 1 ) << "\n"
-    //    << "4:4 " << tileXToLon( 4, 1 ) << ":" << tileYToLat( 4, 1 ) << "\n";
-
     auto tiles = findTilesToProcess( mapZoomLevel, x, y );
-    
+
     //TSP() << "Visible tiles [" << tiles.size() << "]:";
 
     //for ( const auto& head : tiles )
@@ -112,12 +224,11 @@ bool MapGenerator::visiblePoint( double& lon, double& lat )
 {
     Profiler prof( "MapGenerator::visiblePoint" );
 
-    double x0;
-    double x1;
-    double y0;
-    double y1;
-    std::tie( x0, x1, y0, y1 ) = *getViewBorder();
-    float unitInMeter = *getUnitInMeter();
+    double x0 = viewData_.glX0;
+    double x1 = viewData_.glX1;
+    double y0 = viewData_.glY0;
+    double y1 = viewData_.glY1;
+    float unitInMeter = viewData_.unitInMeter;
     static const float unitLimit = static_cast<float>( defs::earthRadius * unitInMeter );
 
     //TSP() << "Borders in units:\n"
@@ -131,7 +242,7 @@ bool MapGenerator::visiblePoint( double& lon, double& lat )
     }
 
     static const double latLimit = 85.0;    // Safety measure, there are no tiles out of [-85.0511, +85.0511] latitude region
-    std::tie( lon, lat ) = *getProjectionCenter();
+    projector_->projectionCenter( lon, lat );
 
     if ( x0 < -unitLimit && unitLimit < x1 && y0 < -unitLimit && unitLimit < y1 )
     {
@@ -147,10 +258,9 @@ bool MapGenerator::visiblePoint( double& lon, double& lat )
     }
 
     static const int pixelStep = 10;
-    const double meterStep = pixelStep * ( *getMeterInPixel() );
-    int pixelW;
-    int pixelH;
-    std::tie( pixelW, pixelH ) = *getViewPixelSize();
+    const double meterStep = pixelStep * viewData_.meterInPixel;
+    int pixelW = viewData_.pixWidth;
+    int pixelH = viewData_.pixHeight;
     const int xNum = pixelW / pixelStep;
     const int yNum = pixelH / pixelStep;
 
@@ -158,20 +268,15 @@ bool MapGenerator::visiblePoint( double& lon, double& lat )
     double metX1 = x1 / unitInMeter;
     double metY0 = y0 / unitInMeter;
     double metY1 = y1 / unitInMeter;
-    bool ok;
 
     for ( int i = 0; i < xNum; ++i )
     {
-        std::tie( ok, lon, lat ) = *getInvProjection( metX0 + i * meterStep, metY0 );
-
-        if ( ok )
+        if ( projector_->projectInv( metX0 + i * meterStep, metY0, lon, lat ) )
         {
             return true;
         }
 
-        std::tie( ok, lon, lat ) = *getInvProjection( metX0 + i * meterStep, metY1 );
-
-        if ( ok )
+        if ( projector_->projectInv( metX0 + i * meterStep, metY1, lon, lat ) )
         {
             return true;
         }
@@ -179,16 +284,12 @@ bool MapGenerator::visiblePoint( double& lon, double& lat )
 
     for ( int i = 0; i < yNum; ++i )
     {
-        std::tie( ok, lon, lat ) = *getInvProjection( metX0, metY0 + i * meterStep );
-
-        if ( ok )
+        if ( projector_->projectInv( metX0, metY0 + i * meterStep, lon, lat ) )
         {
             return true;
         }
 
-        std::tie( ok, lon, lat ) = *getInvProjection( metX1, metY0 + i * meterStep );
-
-        if ( ok )
+        if ( projector_->projectInv( metX1, metY0 + i * meterStep, lon, lat ) )
         {
             return true;
         }
@@ -260,12 +361,11 @@ bool MapGenerator::tileVisible( TileHead th )
 {
     Profiler prof( "MapGenerator::tileVisible" );
 
-    double x0;
-    double x1;
-    double y0;
-    double y1;
-    std::tie( x0, x1, y0, y1 ) = *getViewBorder();
-    float unitInMeter = *getUnitInMeter();
+    double x0 = viewData_.glX0;
+    double x1 = viewData_.glX1;
+    double y0 = viewData_.glY0;
+    double y1 = viewData_.glY1;
+    float unitInMeter = viewData_.unitInMeter;
     x0 /= unitInMeter;
     x1 /= unitInMeter;
     y0 /= unitInMeter;
@@ -280,15 +380,13 @@ bool MapGenerator::tileVisible( TileHead th )
     double ty;
     double lon;
     double lat;
-    bool ok;
 
     for ( int i = 0; i < 4; ++i )
     {
         lon = tileXToLon( corners[i].x, corners[i].z );
         lat = tileYToLat( corners[i].y, corners[i].z );
-        std::tie( ok, tx, ty ) = *getFwdProjection( lon, lat );
 
-        if ( !ok )
+        if ( !projector_->projectFwd( lon, lat, tx, ty ) )
         {
             continue;
         }
@@ -307,14 +405,14 @@ void MapGenerator::composeTileTexture( const std::vector<TileHead>& vec )
 {
     Profiler prof( "MapGenerator::composeTileTexture" );
 
-    TileTexture tt;
-    tt.tileCount = vec.size();
-    tt.tileFilled = 0;
-    const int numX = static_cast<int>( std::ceil( std::sqrt( tt.tileCount ) ) );
-    const int numY = static_cast<int>( std::ceil( static_cast<double>( tt.tileCount ) / numX ) );
+    tileTex_.tileCount = vec.size();
+    tileTex_.tileFilled = 0;
+    const int numX = static_cast<int>( std::ceil( std::sqrt( tileTex_.tileCount ) ) );
+    const int numY = static_cast<int>( std::ceil( static_cast<double>( tileTex_.tileCount ) / numX ) );
     const int sideX = numX * defs::tileSide;
     const int sideY = numY * defs::tileSide;
-    tt.textureSize = std::make_tuple( sideX, sideY );
+    tileTex_.textureSize = std::make_tuple( numX, numY );
+    tileTex_.tiles.clear();
 
     int row = 0;
     int col = 0;
@@ -328,23 +426,126 @@ void MapGenerator::composeTileTexture( const std::vector<TileHead>& vec )
         body.lon1 = tileXToLon( head.x + 1, head.z );
         body.lat0 = tileYToLat( head.y + 1, head.z );
         body.lat1 = tileYToLat( head.y, head.z );
-        const float tx = static_cast<float>( row * defs::tileSide );
-        const float ty = static_cast<float>( col * defs::tileSide );
+        const float tx = static_cast<float>( col * defs::tileSide );
+        const float ty = static_cast<float>( row * defs::tileSide );
         body.tx0 = tx / static_cast<float>( sideX );
         body.tx1 = ( tx + defs::tileSide ) / static_cast<float>( sideX );
         body.ty0 = ty / static_cast<float>( sideY );
         body.ty1 = ( ty + defs::tileSide ) / static_cast<float>( sideY );
-        tt.tiles.emplace( std::move( head ), std::move( body ) );
+        body.row = row;
+        body.col = col;
+        tileTex_.tiles.emplace( std::move( head ), std::move( body ) );
 
-        if ( ++row == numX )
+        if ( ++col == numX )
         {
-            row = 0;
-            ++col;
+            col= 0;
+            ++row;
         }
     }
 
-    sendTileTexture( tt );
     requestTiles( tileHeads );
+    vboFromTileTexture( tileTex_ );
+}
+
+
+void MapGenerator::vboFromTileTexture( TileTexture tt )
+{
+    static const int chunks = 10;
+
+    vbo_.clear();
+    vbo_.reserve( 24 * tt.tileCount * chunks );
+
+    for ( const auto& tile : tt.tiles )
+    {
+        const auto& body = tile.second;
+        const double chunkLon = ( body.lon1 - body.lon0 ) / chunks;
+        const double chunkLat = ( body.lat1 - body.lat0 ) / chunks;
+        const float chunkTx = ( body.tx1 - body.tx0 ) / chunks;
+        const float chunkTy = ( body.ty1 - body.ty0 ) / chunks;
+
+        for ( int i = 0; i < chunks; ++i )
+        {
+            double lon[4];
+            lon[0] = body.lon0 + i * chunkLon;
+            lon[1] = body.lon0 + ( i + 1 ) * chunkLon;
+            lon[2] = lon[1];
+            lon[3] = lon[0];
+            float tx[4];
+            tx[0] = body.tx0 + i * chunkTx;
+            tx[1] = body.tx0 + ( i + 1 )* chunkTx;
+            tx[2] = tx[1];
+            tx[3] = tx[0];
+
+            for ( int j = 0; j < chunks; ++j )
+            {
+                double lat[4];
+                lat[0] = body.lat0 + j * chunkLat;
+                lat[1] = lat[0];
+                lat[2] = body.lat0 + ( j + 1 ) * chunkLat;
+                lat[3] = lat[2];
+                float ty[4];
+                ty[0] = body.ty0 + j * chunkTy;
+                ty[1] = ty[0];
+                ty[2] = body.ty0 + ( j + 1 ) * chunkTy;
+                ty[3] = ty[2];
+
+                std::vector<int> ind;
+                GLfloat x[4];
+                GLfloat y[4];
+                double px;  // projected x
+                double py;  // projected y
+
+                for ( int n = 0; n < 4; ++n )
+                {
+                    if ( projector_->projectFwd( lon[n], lat[n], px, py ) )
+                    {
+                        ind.emplace_back( n );
+                        x[n] = static_cast<GLfloat>( px * viewData_.unitInMeter );
+                        y[n] = static_cast<GLfloat>( py * viewData_.unitInMeter );
+                    }
+                }
+
+                if ( ind.size() > 2 )
+                {
+                    std::vector<GLfloat> vecChunk = {
+                        x[ind[0]], y[ind[0]], tx[ind[0]], ty[ind[0]],
+                        x[ind[1]], y[ind[1]], tx[ind[1]], ty[ind[1]],
+                        x[ind[2]], y[ind[2]], tx[ind[2]], ty[ind[2]]
+                    };
+
+                    if ( ind.size() == 4 )
+                    {
+                        vecChunk.insert( vecChunk.end(), {
+                            x[ind[0]], y[ind[0]], tx[ind[0]], ty[ind[0]],
+                            x[ind[2]], y[ind[2]], tx[ind[2]], ty[ind[2]],
+                            x[ind[3]], y[ind[3]], tx[ind[3]], ty[ind[3]] }
+                        );
+                    }
+
+                    std::move( vecChunk.begin(), vecChunk.end(), std::back_inserter( vbo_ ) );
+                }
+            }
+        }
+    }
+
+    calcedVbo_.store( true );
+    finalize();
+}
+
+
+void MapGenerator::finalize()
+{
+    if ( gotTiles_.load() && calcedVbo_.load() )
+    {
+        //int w = std::get<0>( tileTex_.textureSize ) * defs::tileSide;
+        //int h = std::get<1>( tileTex_.textureSize ) * defs::tileSide;
+        //updateMapTexture( vbo_, w, h, data_ );
+        
+        calcedVbo_.store( false );
+        gotTiles_.store( false );
+
+        cleanupCheck();
+    }
 }
 
 

--- a/lib/src/Renderer.cpp
+++ b/lib/src/Renderer.cpp
@@ -13,6 +13,7 @@ namespace gv {
 
 
 Renderer::Renderer()
+    : mapReady_( false )
 {
     shaderSimple_.reset( new support::Shader( "shaders/simple.vs", "shaders/simple.fs" ) );
     shaderTexture_.reset( new support::Shader( "shaders/texture.vs", "shaders/texture.fs" ) );
@@ -51,6 +52,7 @@ void Renderer::render()
     shaderTexture_->use();
     glUniformMatrix4fv( stProj_, 1, GL_FALSE, glm::value_ptr( proj ) );
 
+    if ( mapReady_ )
     {   // Map tiles
         boost::optional<std::tuple<GLuint, GLuint, GLsizei>> optMapTiles = renderMapTiles();
 
@@ -76,6 +78,7 @@ void Renderer::render()
     shaderSimple_->use();
     glUniformMatrix4fv( ssProj_, 1, GL_FALSE, glm::value_ptr( proj ) );
 
+    /*
     {   // Simple Triangle
         glUniform4fv( ssColor_, 1, glm::value_ptr( glm::vec4( 1.0f, 0.0f, 0.0f, 1.0f ) ) );
 
@@ -95,6 +98,7 @@ void Renderer::render()
             }
         }
     }
+    //*/
 
     {   // Wire Globe
         glUniform4fv( ssColor_, 1, glm::value_ptr( glm::vec4( 1.0f, 1.0f, 0.0f, 1.0f ) ) );
@@ -116,6 +120,12 @@ void Renderer::render()
             }
         }
     }
+}
+
+
+void Renderer::setMapReady( bool val )
+{
+    mapReady_ = val;
 }
 
 

--- a/lib/src/Viewport.cpp
+++ b/lib/src/Viewport.cpp
@@ -1,6 +1,5 @@
 ﻿#include <algorithm>
 #include <cmath>
-#include <iostream>
 
 #include "Defines.h"
 #include "Viewport.h"
@@ -64,6 +63,7 @@ void Viewport::move( int x, int y )
 
 void Viewport::zoom( int steps )
 {
+    const auto prevUnitInPixel = unitInPixel_;
     const int sign = steps > 0 ? 1 : -1;
 
     for ( int i = 0; i < std::abs( steps ); ++i )
@@ -73,6 +73,12 @@ void Viewport::zoom( int steps )
 
     unitInPixel_ = std::min( unitInPixel_, maxUnitInPixel_ );
     unitInPixel_ = std::max( unitInPixel_, minUnitInPixel_ );
+
+    if ( prevUnitInPixel == unitInPixel_)
+    {
+        return;
+    }
+
     meterInPixel_ = unitInPixel_ / unitInMeter_;
     const auto prevUnitW = unitW_;
     const auto prevUnitH = unitH_;
@@ -88,6 +94,22 @@ void Viewport::center()
 {
     panX_ = panY_ = 0;
     setProjection();
+}
+
+
+ViewData Viewport::viewData() const
+{
+    ViewData vd;
+    vd.unitInMeter = unitInMeter_;
+    vd.meterInPixel = meterInPixel_;
+    vd.mapZoomLevel = mapZoomLevel( defs::tileSide );
+    vd.glX0 = unitX_ + panX_;
+    vd.glX1 = unitX_ + panX_ + unitW_;
+    vd.glY0 = unitY_ + panY_;
+    vd.glY1 = unitY_ + panY_ + unitH_;
+    vd.pixWidth = pixelW_;
+    vd.pixHeight = pixelH_;
+    return vd;
 }
 
 
@@ -146,21 +168,7 @@ void Viewport::setProjection()
         unitY_ + panY_, unitY_ + panY_ + unitH_,
         zNear_, zFar_ ) *
         view;
-    projectionUpdated();
-}
-
-
-void Viewport::testPrint() const
-{
-    std::cout
-        << "pixelW_ = " << pixelW_ << "\n"
-        << "pixelH_ = " << pixelH_ << "\n"
-        << "unitW_ = " << unitW_ << "\n"
-        << "unitH_ = " << unitH_ << "\n"
-        << "unitX_ = " << unitX_ << "\n"
-        << "unitY_ = " << unitY_ << "\n"
-        << "unitInPixel_ = " << unitInPixel_ << "\n"
-        << std::endl;
+    viewUpdated( viewData() );
 }
 
 

--- a/lib/src/support/Profiler.cpp
+++ b/lib/src/support/Profiler.cpp
@@ -1,6 +1,12 @@
+#include <mutex>
 #include <sstream>
 
 #include <Profiler.h>
+
+
+namespace {
+std::mutex mutexMap;
+}
 
 
 namespace gv {
@@ -38,6 +44,8 @@ void Profiler::printStatistics( std::ostream& os )
 
 void Profiler::getStatistics( std::ostream& os )
 {
+    std::lock_guard<std::mutex> lock( mutexMap );
+
     if ( map_.empty() )
     {
         os
@@ -76,6 +84,8 @@ std::string Profiler::getStatistics()
 
 void Profiler::addStatistic( const std::string& name, int milli )
 {
+    std::lock_guard<std::mutex> lock( mutexMap );
+
     auto it = map_.find( name );
     if ( it == map_.end() )
     {


### PR DESCRIPTION
+ ViewData class
+ MapGenerator keeps shared_ptr<Projector>
- MapGenerator doesn't need signals to project no more
+ Renderer draws map tiles only when mapReady_ == true (changing by signals)
- removed Viewport::testPrint
+ TileBody has row and column of the tile
~ TileTexture.textureSize holds number of rows and columns (and not width and height)
~ GlobeViewer redirects signals to glue modules
- red triangle is finally gone